### PR TITLE
Fix Featured News blank on home page

### DIFF
--- a/src/_content/posts/announcing-date-change.md
+++ b/src/_content/posts/announcing-date-change.md
@@ -1,5 +1,6 @@
 ---
 author: DEFNA Board
+featured: true
 hidden: false
 category: Announcements
 published_datetime: 2026-02-12T18:00:00Z

--- a/src/_content/posts/call-for-proposals.md
+++ b/src/_content/posts/call-for-proposals.md
@@ -1,5 +1,6 @@
 ---
 author: Communications Team
+featured: true
 category: General
 published_datetime: 2026-02-20 12:00:00
 layout: post


### PR DESCRIPTION
## Summary
- Add `featured: true` to frontmatter of both blog posts so the Featured News section on the home page renders them
- The template in `src/index.html` filters on `post.data.featured`, but neither post had this property set

Fixes #16