### PR TITLE
Add CFP and Opportunity Grants CTAs to home page hero

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -35,8 +35,13 @@ templateClass: homepage
         {% endcomment %}
       </div>
       <div class="justify-center p-5 button-group">
+        <a class="text-lg font-bold button" href="{{ site.cfp_application }}">Submit a Talk</a>
+        <a class="text-lg font-bold button" href="{{ site.opportunity_grant_application }}">Apply for a Grant</a>
         <a class="text-lg font-bold button" href="{{ site.mailing_list }}">Join Mailing List</a>
       </div>
+      <p class="text-lg text-center">
+        CFP and Opportunity Grant deadline: <strong>March 16, 2026</strong>
+      </p>
     </section>
   </div>
 


### PR DESCRIPTION
## Summary

- Adds "Submit a Talk" and "Apply for a Grant" buttons to the home page hero alongside the existing "Join Mailing List" button
- Displays the shared CFP and Opportunity Grant deadline (March 16, 2026) below the buttons

Closes #15

<img width="1392" height="991" alt="Screenshot 2026-02-25 at 11 17 03 AM" src="https://github.com/user-attachments/assets/fe893cb2-c2d8-4527-be93-9c076edbb607" />
