### PR TITLE
Add mentorship info to speaking page.

### DIFF
--- a/src/speaking/index.html
+++ b/src/speaking/index.html
@@ -65,7 +65,7 @@ Not up for a full-on talk or tutorial? Looking to give your first talk at a conf
 
 ### Mentorship
 
-How about some help?! Presenters, regardless of experience, sometimes want a little help. If you'd like any help in proposing, preparing, or presenting your talk, send an email to [program@djangocon.us](mailto:program@djangocon.us) and we'll connect you with a mentor! A mentor is an experienced presenter who has volunteered to help other presenters. For first-time presenters, non-native English speakers, under-confident or uncertain speakers, or anyone who would just appreciate another set of eyes, our mentors are here to help.
+Not sure if your idea is ready? Want help shaping your proposal? We offer mentorship at every stage — from crafting your submission to delivering your talk. Email [program@djangocon.us](mailto:program@djangocon.us) and we'll connect you with an experienced presenter who has volunteered to help. [Learn more about our mentorship program.](/speaking/speaker-resources/#need-some-help-with-your-presentation)
 
 ### Speaker Travel Assistance
 


### PR DESCRIPTION
@PeterGrand I didn't want to duplicate the blurb that was already on the resources page. I added a shorter one to the index page with a link to the resources page instead.