### PR TITLE
Close the CFP and remove Submit a Talk buttons

### DIFF
--- a/src/_includes/nav.html
+++ b/src/_includes/nav.html
@@ -30,7 +30,7 @@
       <a href="/venue/" data-menu-trigger aria-haspopup="true" aria-expanded="false">Speaking</a>
       <ul data-menu-list class="hidden site-nav-menu">
         <li><a href="/speaking/" role="menuitem">Speaking at DjangoCon US</a></li>
-        <li><a href="{{ site.cfp_application }}" target="_blank" role="menuitem">Submit a Proposal</a></li>
+        {% comment %}<li><a href="{{ site.cfp_application }}" target="_blank" role="menuitem">Submit a Proposal</a></li>{% endcomment %}
         <li><a href="/speaking/speaker-resources/"  role="menuitem">Speaker Resources</a></li>
     </ul>
   </li>

--- a/src/index.html
+++ b/src/index.html
@@ -35,14 +35,13 @@ templateClass: homepage
         {% endcomment %}
       </div>
       <div class="justify-center p-5 button-group">
-        <a class="text-lg font-bold button" href="{{ site.cfp_application }}">Submit a Talk</a>
         <a class="text-lg font-bold button" href="{{ site.opportunity_grant_application }}">Apply for a Grant</a>
         <a class="text-lg font-bold button" href="{{ site.mailing_list }}">Join Mailing List</a>
         <a class="text-lg font-bold button" href="{{ site.hotel_reservation_link }}">Book a Hotel Room</a>
       </div>
       <p class="text-lg text-center">
         Opportunity Grant deadline: <strong>March 16, 2026</strong><br>
-        Talk Proposal deadline: <strong>March 23, 2026</strong>
+        Talk Proposal deadline: <strong>March 23, 2026</strong> (closed)
       </p>
     </section>
   </div>

--- a/src/speaking/index.html
+++ b/src/speaking/index.html
@@ -5,6 +5,7 @@ description: |
   Information about submitting a proposal to speak at DjangoCon US
 ---
 
+{% comment %}
 ## Our Call for Proposals is Open!
 
 <a href="{{ site.cfp_application }}" class="button button-lg">Submit your talk</a>
@@ -14,10 +15,9 @@ You can also submit an application for an <a href="{{ site.opportunity_grant_app
 The Call for Proposals is open until <strong><a href="https://time.is/1100AM_23_March_2026_in_Chicago?DjangoCon_US_CFP_Closes">March 23, 2026 at 11:00 AM CDT</a></strong> (America/Chicago).
 
 We encourage you to submit multiple talks, but we generally cannot accept more than one submission per presenter (incuding any co-presenters).
-
-{% comment %}
-Our Call for Proposals is now closed. Decision notifications will be sent by July 8th, 2024.
 {% endcomment %}
+
+Our Call for Proposals is now closed. Decision notifications will be sent by June 8, 2026.
 
 ## Why Speak at DjangoCon US?
 


### PR DESCRIPTION
## Summary
- Removed "Submit a Talk" button from the homepage
- Commented out "Submit a Proposal" link in the nav menu
- Updated the speaking page to show "CFP is now closed" with notification date of June 8, 2026
- Added "(closed)" to the talk proposal deadline on the homepage