### PR TITLE
Add contribution sprints blog post.

### DIFF
--- a/src/_content/posts/contribution-sprints.md
+++ b/src/_content/posts/contribution-sprints.md
@@ -1,7 +1,7 @@
 ---
-author: DjangoCon US Communications Team
+author: DjangoCon US Marketing Team
 category: General
-published_datetime: 2026-06-02 12:00:00-04:00
+published_datetime: 2026-06-03 12:00:00-04:00
 layout: post
 title: Contribute to Django at the Contribution Sprints!
 description: "DjangoCon US Contribution Sprints are August 27–28, 2026 in Chicago and are free and open to all. Whether you write code or not, there's a place for you to help open source projects thrive"

--- a/src/_content/posts/contribution-sprints.md
+++ b/src/_content/posts/contribution-sprints.md
@@ -13,6 +13,8 @@ cover:
 
 We are excited to talk to you about contribution sprints at DjangoCon US! They are being held **Thursday, August 27th and Friday, August 28th, 2026**, from **9am to 5pm** each day at the **[voco Chicago Downtown](https://www.ihg.com/voco/hotels/us/en/chicago/chiwp/hoteldetail)**, the same venue as the main conference and virtually on our conference Slack. **They are free to attend and open to everyone**.
 
+<!-- excerpt -->
+
 📣 **[Get your ticket]({{site.ticket_link}})** and join us!
 
 ## What is a contribution sprint?

--- a/src/_content/posts/contribution-sprints.md
+++ b/src/_content/posts/contribution-sprints.md
@@ -1,0 +1,88 @@
+---
+author: DjangoCon US Communications Team
+category: General
+published_datetime: 2026-07-07 12:00:00-04:00
+layout: post
+title: Contribute to Django at the Contribution Sprints!
+
+cover:
+    url: /assets/img/2025/sprints.jpg
+    alt: "A photo of people at the sprints. Several people are at desks, looking intently at laptops. There is a group of three people discussing something in the background."
+---
+
+We are excited to talk to you about contribution sprints at DjangoCon US! They are being held **Thursday, August 27th and Friday, August 28th, 2026**, from **9am to 5pm** each day at the **[voco Chicago Downtown](https://www.ihg.com/voco/hotels/us/en/chicago/chiwp/hoteldetail)**, the same venue as the main conference and virtually on our conference Slack. **They are free to attend and open to everyone**.
+
+📣 **[Get your ticket]({{site.ticket_link}})** and join us!
+
+## What is a contribution sprint?
+
+Contribution Sprints are a superset of Development Sprints. They serve the same purpose while increasing the range of contribution types and opportunities.
+
+Let’s start with what some people already know: [Development Sprints](https://2022.djangocon.us/news/dev-sprint-attendees/) are an opportunity for people who maintain open source projects (or want to get involved in doing so) to sit and work together on that goal. They have mostly focused on contributing code, tests, and documentation. However, open source projects often need more than those things. This is especially true as a project grows. Development Sprints are one type of Contribution Sprint.
+
+Many of the new things a project needs as it grows fall under the idea of project governance. Here’s a short list of general governance issues a project may face as it grows:
+
+- General project governance (Who leads the project? How? How are decisions made? How are new leaders developed? How are conflicts resolved?)
+- Onboarding new contributors
+- Funding/Finance: does your project want it? Is it needed? Who will manage it? How will they manage it?
+- Project marketing
+- Graphic/logo design
+- Legal/licensing questions
+- Clarifying code, documentation, and testing conventions (metadata that guides the rest of your contribution process)
+
+There is an excellent video on this topic by [Shauna Gordon-McKeon](https://www.youtube.com/watch?v=b2WHTNE4AZk), part of the PyCon US 2023 [Maintainers Summit](https://www.youtube.com/@MaintainersSummit). If you maintain a project, or are interested in helping maintain one, we recommend checking it out.
+
+## How & Why To Lead a Contribution Sprint
+
+The "why" is clear: if you’ve realized your project needs help especially with things beyond code this is a great opportunity to find that help.
+
+The "how" can be trickier, so here are some specific suggestions:
+
+- Think about the non-code needs your project has.
+- Ask for help in those areas.
+- Document the need for that help in your project's **CONTRIBUTING** documentation.
+- Make it clear in all of your communications that you’re looking for more than just code contributions. Many people still think contributing to an open source project *only* means writing code.
+
+## How & Why to Join a Contribution Sprint
+
+The "why" can vary. Maybe you don’t feel confident enough to contribute code (you probably are, but we understand the feeling). Or maybe you have skills in non-code areas that you would love to use to help a project thrive.
+
+The "how" starts with identifying your strengths, then connecting with projects that might need them. Shauna’s video is a great starting point. Once you identify a project that interests you, reach out! Sometimes a project doesn’t realize what kind of help it needs until someone offers it.
+
+## Preparing to Lead or Organize a Sprint
+
+If you’re a project maintainer or contributor, a bit of preparation can help make the most of the sprint and avoid burnout. Most open source maintainers are unpaid volunteers, we appreciate you.
+
+Here are some steps you can take ahead of time:
+
+- Make sure your **CONTRIBUTING** guide is up to date. If your project doesn’t have one, check out [Django REST Framework](https://www.django-rest-framework.org/community/contributing/), [pytest](https://github.com/pytest-dev/pytest/blob/main/CONTRIBUTING.rst), [Django](https://docs.djangoproject.com/en/dev/internals/contributing/), or [CPython](https://devguide.python.org/) for inspiration.
+- Include setup instructions, test commands, code style, CI guidelines, and PR templates.
+- Rather than just flagging "beginner-friendly" issues, try breaking down large issues into smaller, approachable tasks.
+
+## Supporting Contributors as a Non-Maintainer
+
+If you're an active contributor (even without commit access), you can:
+
+- Help mentor newcomers with patience and empathy.
+- Gauge each contributor’s experience level and tailor your help.
+- Update documentation as needed to reflect your mentoring experience.
+- Break down complex issues into bite-sized contributions.
+- Let someone co-pilot an issue with you.
+
+## Tips for Hybrid Participation
+
+We are continuing the hybrid format: virtual and in-person. This brings both challenges and opportunities. While you might miss the spontaneity of in-person collaboration, working synchronously online is a powerful experience. Make sure:
+
+- Your project uses real-time chat (Slack, Zulip, Discord, etc.)
+- Your docs are easily accessible to virtual attendees.
+- You’re ready to share screens, links, and tasks in real time.
+
+## Final Notes
+
+The Contribution Sprints are free and open to everyone. They will run **August 27–28, 2026 from 9am to 5pm CDT** at **voco Chicago Downtown** and online via Slack.
+
+- Want to lead or organize a sprint? Great!
+- Want to help? We’d love to have you.
+- Have questions? Email us at **[sprints@djangocon.us](mailto:sprints@djangocon.us)**.
+
+🎟️ **[Get your ticket now]({{site.ticket_link}})** and be part of something awesome!

--- a/src/_content/posts/contribution-sprints.md
+++ b/src/_content/posts/contribution-sprints.md
@@ -1,9 +1,10 @@
 ---
 author: DjangoCon US Communications Team
 category: General
-published_datetime: 2026-07-07 12:00:00-04:00
+published_datetime: 2026-06-02 12:00:00-04:00
 layout: post
 title: Contribute to Django at the Contribution Sprints!
+description: "DjangoCon US Contribution Sprints are August 27–28, 2026 in Chicago and are free and open to all. Whether you write code or not, there's a place for you to help open source projects thrive"
 
 cover:
     url: /assets/img/2025/sprints.jpg


### PR DESCRIPTION
This updates the dates from the 2025 blog post, removes the form submission and removes a blog post mention.

The date may need to be updated, depending on when this gets posted.