### PR TITLE
Conduct typos

### DIFF
--- a/src/about/conduct.html
+++ b/src/about/conduct.html
@@ -8,29 +8,51 @@ redirect_from: /coc/
 hero_graphic: /assets/img/2026/conduct.svg
 ---
 
-{% layout "_layouts/page.html" %}
-
-{% block hero_content %}
-  <p class="prose">
-    DjangoCon US is dedicated to providing a fun harassment-free conference experience for everyone, regardless of gender, gender identity, sexual orientation, disability, physical appearance, body size, race, or religion.
-  </p>
-{% endblock %}
-
-{% block wrapper %}
+{% layout "_layouts/page.html" %} {% block hero_content %}
+<p class="prose">
+  DjangoCon US is dedicated to providing a fun harassment-free conference
+  experience for everyone, regardless of gender, gender identity, sexual
+  orientation, disability, physical appearance, body size, race, or religion.
+</p>
+{% endblock %} {% block wrapper %}
 <section>
   <div class="wrapper">
     <div class="banner">
       <div>
-        <p>Be kind to others. Do not insult or put down other attendees. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for DjangoCon US.</p>
-        <p>Attendees violating these rules may be asked to leave the conference without a refund at the sole discretion of the conference organizers.</p>
-        <p>Thank you for helping make this a welcoming, friendly event for all.</p>
+        <p>
+          Be kind to others. Do not insult or put down other attendees. Behave
+          professionally. Remember that harassment and sexist, racist, or
+          exclusionary jokes are not appropriate for DjangoCon US.
+        </p>
+        <p>
+          Attendees violating these rules may be asked to leave the conference
+          without a refund at the sole discretion of the conference organizers.
+        </p>
+        <p>
+          Thank you for helping make this a welcoming, friendly event for all.
+        </p>
       </div>
 
       <aside class="bg-white">
         <p class="site-h3">Need help?</p>
 
-        <p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact the conference Code of Conduct committee at <a href="mailto:{{ site.conduct_email }}" class="link">{{ site.conduct_email }}</a>{% comment %} or <a href="tel:201-899-4189" class="link">201-899-4189</a>{% endcomment %}.</p>
-        <p>To ensure we receive all the necessary information, please refer to our <a href="#procedures-for-reporting-incidents" class="link">Procedures for Reporting Incidents</a>.</p>
+        <p>
+          If you are being harassed, notice that someone else is being harassed,
+          or have any other concerns, please contact the conference Code of
+          Conduct committee at
+          <a href="mailto:{{ site.conduct_email }}" class="link"
+            >{{ site.conduct_email }}</a
+          >{% comment %} or
+          <a href="tel:201-899-4189" class="link">201-899-4189</a>{% endcomment
+          %}.
+        </p>
+        <p>
+          To ensure we receive all the necessary information, please refer to
+          our
+          <a href="#procedures-for-reporting-incidents" class="link"
+            >Procedures for Reporting Incidents</a
+          >.
+        </p>
       </aside>
     </div>
   </div>
@@ -40,13 +62,15 @@ hero_graphic: /assets/img/2026/conduct.svg
   <div class="wrapper">
     <div class="grid-1-2">
       <section class="prose">
-{% markdown %}
-## Important Numbers
-
-Conference staff will be happy to help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
-
-If your physical safety or the physical safety of others is at risk, please dial 911. If you are outside of Chicago, or on a cell phone, and need to access Chicago's 911 services, dial [(312) 746-6000](tel:+1-312-746-6000). For other needs, contact the relevant authorities below.
-{% endmarkdown %}
+        {% markdown %} ## Important Numbers Conference staff will be happy to
+        help participants contact venue security or local law enforcement,
+        provide escorts, or otherwise assist those experiencing harassment to
+        feel safe for the duration of the conference. We value your attendance.
+        If your physical safety or the physical safety of others is at risk,
+        please dial 911. If you are outside of Chicago, or on a cell phone, and
+        need to access Chicago's 911 services, dial [(312)
+        746-6000](tel:+1-312-746-6000). For other needs, contact the relevant
+        authorities below. {% endmarkdown %}
       </section>
 
       <section class="prose">
@@ -66,13 +90,34 @@ If your physical safety or the physical safety of others is at risk, please dial
     <section class="prose max-w-none mt-6">
       <h2 class="site-h3">Local authorities</h2>
 
-      <ul class="gap-2 list-disc lg:gap-12 md:columns-2 lg:columns-3 *:break-inside-avoid max-w-none">
+      <ul
+        class="gap-2 list-disc lg:gap-12 md:columns-2 lg:columns-3 *:break-inside-avoid max-w-none"
+      >
         <li>Emergency: 911</li>
         <li>Chicago Police Helpline: <a href="tel:311">311</a></li>
-        <li>Chicago Police (Non-Emergency): <a href="tel:+1-312-746-6000">(312) 746-6000</a></li>
-        <li>Crime Check (to report Non-Emergency incidents): <a href="https://www.chicagopolice.org/online-crime-reporting/">chicagopolice.org/online-crime-reporting</a></li>
-        <li>Sexual Assault Crisis Line/Victims Crisis Line (24 hours): <a href="tel:+1-888-293-2080">(888) 293-2080</a></li>
-        <li>Nearest Hospital: <a href="https://maps.app.goo.gl/1YUMVFSdwZndiHMj9">John H. Stroger, Jr. Hospital of Cook County</a> 1969 W Ogden Ave, Chicago, IL 60612<br /><a href="tel:+1-312-864-6000">(312) 864-6000</a></li>
+        <li>
+          Chicago Police (Non-Emergency):
+          <a href="tel:+1-312-746-6000">(312) 746-6000</a>
+        </li>
+        <li>
+          Crime Check (to report Non-Emergency incidents):
+          <a href="https://www.chicagopolice.org/online-crime-reporting/"
+            >chicagopolice.org/online-crime-reporting</a
+          >
+        </li>
+        <li>
+          Sexual Assault Crisis Line/Victims Crisis Line (24 hours):
+          <a href="tel:+1-888-293-2080">(888) 293-2080</a>
+        </li>
+        <li>
+          Nearest Hospital:
+          <a href="https://maps.app.goo.gl/1YUMVFSdwZndiHMj9"
+            >John H. Stroger, Jr. Hospital of Cook County</a
+          >
+          1969 W Ogden Ave, Chicago, IL 60612<br /><a href="tel:+1-312-864-6000"
+            >(312) 864-6000</a
+          >
+        </li>
       </ul>
     </section>
   </div>
@@ -81,61 +126,57 @@ If your physical safety or the physical safety of others is at risk, please dial
 <div class="block-container">
   <div class="wrapper">
     <div class="prose mx-auto">
-{% markdown %}
-## Procedures for Reporting Incidents
-
-If you believe someone has violated the Code of Conduct, we encourage you to report it.
-
-If you are unsure whether the incident is a violation, or whether the space where it happened is covered by the Code of Conduct, we encourage you to still report it.
-
-We are fine with receiving reports where we decide to take no action for the sake of creating a safer space.
-
-### Examples of Inappropriate Behavior
--   Harassment of any participants in any form
--   Deliberate intimidation, stalking, or following
--   Logging or taking screenshots of online activity for harassment purposes
--   Publishing others' private information, such as a physical or electronic address, without explicit permission
--   Violent threats or language directed against another person
--   Incitement of violence or harassment towards any individual, including encouraging a person to commit suicide or to engage in self-harm
--   Creating additional online accounts in order to harass another person or circumvent a ban
--   Sexual language and imagery in online communities or in any conference venue, including talks
--   Insults, put downs, or jokes that are based upon stereotypes, that are exclusionary, or that hold others up for ridicule
--   Excessive swearing
--   Unwelcome sexual attention or advances
--   Unwelcome physical contact, including simulated physical contact (eg, textual descriptions like "hug" or "backrub") without consent or after a request to stop
--   Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
--   Sustained disruption of online community discussions, in-person presentations, or other in-person events
--   Continued one-on-one communication after requests to cease
--   Other conduct that is inappropriate for a professional audience including people of many different backgrounds
-
-This list is not an exhaustive list of all inappropriate behavior that is unacceptable at DjangoCon US.
-
-### General Reporting Procedure
-
-The best way to contact the DjangoCon Code of Conduct committee is by emailing [{{site.conduct_email}}](mailto:{{site.conduct_email}})
-
-### Report Data
-
-When you make a report via email or phone, please include:
-- Your contact info (so we can get in touch with you if we need to follow up)
-- Date and time of the incident
-- Location of incident
-- Whether the incident is ongoing
-- Description of the incident
-- Identifying information of the reported person: name, physical appearance, height, clothing, voice accent, identifying badge information such as company name, ribbons, or badge number
-- Additional circumstances surrounding the incident
-- Other people involved in or witnesses to the incident and their contact information or description
-
-Please provide as much information as possible.
-
-You will receive feedback promptly or within 24 hours after submitting the report.
-
-### Confidentiality
-
-All reports will be kept confidential. When we discuss incidents with people who are reported, we will anonymize details as much as we can to protect reporter privacy.
-
-However, some incidents happen in one-on-one interactions, and even if the details are anonymized, the reported person may be able to guess who made the report. If you have concerns about retaliation or your personal safety, please note those in your report. We still encourage you to report, so that we can support you while keeping our conference attendees safe. In some cases, we can compile several anonymized reports into a pattern of behavior, and take action on that pattern.
-{% endmarkdown %}
+      {% markdown %} ## Procedures for Reporting Incidents If you believe
+      someone has violated the Code of Conduct, we encourage you to report it.
+      If you are unsure whether the incident is a violation, or whether the
+      space where it happened is covered by the Code of Conduct, we encourage
+      you to still report it. We are fine with receiving reports where we decide
+      to take no action for the sake of creating a safer space. ### Examples of
+      Inappropriate Behavior - Harassment of any participants in any form -
+      Deliberate intimidation, stalking, or following - Logging or taking
+      screenshots of online activity for harassment purposes - Publishing
+      others' private information, such as a physical or electronic address,
+      without explicit permission - Violent threats or language directed against
+      another person - Incitement of violence or harassment towards any
+      individual, including encouraging a person to commit suicide or to engage
+      in self-harm - Creating additional online accounts in order to harass
+      another person or circumvent a ban - Sexual language and imagery in online
+      communities or in any conference venue, including talks - Insults, put
+      downs, or jokes that are based upon stereotypes, that are exclusionary, or
+      that hold others up for ridicule - Excessive swearing - Unwelcome sexual
+      attention or advances - Unwelcome physical contact, including simulated
+      physical contact (eg, textual descriptions like "hug" or "backrub")
+      without consent or after a request to stop - Pattern of inappropriate
+      social contact, such as requesting/assuming inappropriate levels of
+      intimacy with others - Sustained disruption of online community
+      discussions, in-person presentations, or other in-person events -
+      Continued one-on-one communication after requests to cease - Other conduct
+      that is inappropriate for a professional audience including people of many
+      different backgrounds This list is not an exhaustive list of all
+      inappropriate behavior that is unacceptable at DjangoCon US. ### General
+      Reporting Procedure The best way to contact the DjangoCon US Code of
+      Conduct committee is by emailing
+      [{{site.conduct_email}}](mailto:{{site.conduct_email}}) ### Report Data
+      When you make a report via email or phone, please include: - Your contact
+      info (so we can get in touch with you if we need to follow up) - Date and
+      time of the incident - Location of incident - Whether the incident is
+      ongoing - Description of the incident - Identifying information of the
+      reported person: name, physical appearance, height, clothing, voice
+      accent, identifying badge information such as company name, ribbons, or
+      badge number - Additional circumstances surrounding the incident - Other
+      people involved in or witnesses to the incident and their contact
+      information or description Please provide as much information as possible.
+      You will receive feedback promptly or within 24 hours after submitting the
+      report. ### Confidentiality All reports will be kept confidential. When we
+      discuss incidents with people who are reported, we will anonymize details
+      as much as we can to protect reporter privacy. However, some incidents
+      happen in one-on-one interactions, and even if the details are anonymized,
+      the reported person may be able to guess who made the report. If you have
+      concerns about retaliation or your personal safety, please note those in
+      your report. We still encourage you to report, so that we can support you
+      while keeping our conference attendees safe. In some cases, we can compile
+      several anonymized reports into a pattern of behavior, and take action on
+      that pattern. {% endmarkdown %}
     </div>
   </div>
 </div>
@@ -143,57 +184,72 @@ However, some incidents happen in one-on-one interactions, and even if the detai
 <div class="bg-background block-container">
   <div class="wrapper">
     <div class="prose mx-auto">
-{% markdown %}
-## Full Code of Conduct
-
-_To make clear what is expected, all delegates/attendees, speakers, exhibitors, organizers and volunteers at any DjangoCon US event are required to conform to the following Code of Conduct. Organizers will enforce this code throughout the event._
-
-### What the conference is
-
-DjangoCon US is a community conference intended for networking and collaboration in the developer community.
-
-We value the participation of each member of the Django community and want all attendees to have an enjoyable and fulfilling experience. Accordingly, all attendees are expected to show respect and courtesy to other attendees throughout the conference, at all conference events, and in all conference online spaces (such as Slack), whether officially sponsored by DjangoCon US or not.
-
-### Be Kind To Others
-
-Do not insult or put down other attendees. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for DjangoCon US. Attendees violating these rules may be asked to leave the conference without a refund at the sole discretion of the conference organizers.
-
-### Be Respectful
-
-Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We do not tolerate harassment of conference participants in any form.
-
-Harassment includes: offensive verbal comments related to gender, gender identity, sexual orientation, disability, physical appearance, body size, race, religion; sexual images in public spaces; deliberate intimidation, stalking, or following; harassing photography or recording; sustained disruption of talks or other events; repeated or inappropriate direct messaging on conference or social media platforms; inappropriate physical contact; and unwelcome sexual attention.
-
-### Choose Your Words
-
-Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Excessive swearing and offensive jokes are not appropriate for DjangoCon US. We are all adults, capable of having adult conversations. Preface your presentation with appropriate Trigger/Content Warnings, if necessary.
-
-All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery is not appropriate for any conference venue, including talks.
-
-Participants asked to stop any harassing behavior are expected to comply immediately.
-
-Exhibitors in the expo hall, sponsor or vendor booths, or similar activities are also subject to the anti-harassment policy. In particular, exhibitors should not use sexualized images, activities, or other material. Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.
-
-### Weapons Policy
-
-No weapons are allowed at DjangoCon US. Weapons include but are not limited to explosives (including fireworks), guns, and large knives such as those used for hunting or display, as well as any other item used for the purpose of causing injury or harm to others. Anyone seen in possession of one of these items will be asked to leave immediately, and will only be allowed to return without the weapon.
-
-### Photography
-
-In order to make DjangoCon US {{ site.conf_year }} a great experience for everyone, do not photograph, video, or audio record anyone at DjangoCon without their express permission, sought in advance. If someone does not want to be photographed, video or audio recorded, please respect their wishes.
-
-Crowd shots are permitted, but when only the faces of a few people are visible, permission should be sought from all of those individuals.
-
-_If a participant engages in behavior that violates this code of conduct, the conference organizers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund._
-
-## License
-
-This Code of Conduct was forked from the example policy from the [Geek Feminism wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy), created by the Ada Initiative and other volunteers, which is under a Creative Commons Zero license.
-
-This Code of Conduct also incorporates portions from PyCon's Code of Conduct, which is licensed under the [Creative Commons Attribution-ShareAlike 3.0 Unported License](https://creativecommons.org/licenses/by-sa/3.0/).
-
-DjangoCon US [Conference Code of Conduct](/conduct/) is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/).
-{% endmarkdown %}
+      {% markdown %} ## Full Code of Conduct _To make clear what is expected,
+      all delegates/attendees, speakers, exhibitors, organizers and volunteers
+      at any DjangoCon US event are required to conform to the following Code of
+      Conduct. Organizers will enforce this code throughout the event._ ### What
+      the conference is DjangoCon US is a community conference intended for
+      networking and collaboration in the developer community. We value the
+      participation of each member of the Django community and want all
+      attendees to have an enjoyable and fulfilling experience. Accordingly, all
+      attendees are expected to show respect and courtesy to other attendees
+      throughout the conference, at all conference events, and in all conference
+      online spaces (such as Slack), whether officially sponsored by DjangoCon
+      US or not. ### Be Kind To Others Do not insult or put down other
+      attendees. Behave professionally. Remember that harassment and sexist,
+      racist, or exclusionary jokes are not appropriate for DjangoCon US.
+      Attendees violating these rules may be asked to leave the conference
+      without a refund at the sole discretion of the conference organizers. ###
+      Be Respectful Not all of us will agree all the time, but disagreement is
+      no excuse for poor behavior and poor manners. We do not tolerate
+      harassment of conference participants in any form. Harassment includes:
+      offensive verbal comments related to gender, gender identity, sexual
+      orientation, disability, physical appearance, body size, race, religion;
+      sexual images in public spaces; deliberate intimidation, stalking, or
+      following; harassing photography or recording; sustained disruption of
+      talks or other events; repeated or inappropriate direct messaging on
+      conference or social media platforms; inappropriate physical contact; and
+      unwelcome sexual attention. ### Choose Your Words Be careful in the words
+      that you choose. Remember that sexist, racist, and other exclusionary
+      jokes can be offensive to those around you. Excessive swearing and
+      offensive jokes are not appropriate for DjangoCon US. We are all adults,
+      capable of having adult conversations. Preface your presentation with
+      appropriate Trigger/Content Warnings, if necessary. All communication
+      should be appropriate for a professional audience including people of many
+      different backgrounds. Sexual language and imagery is not appropriate for
+      any conference venue, including talks. Participants asked to stop any
+      harassing behavior are expected to comply immediately. Exhibitors in the
+      expo hall, sponsor or vendor booths, or similar activities are also
+      subject to the anti-harassment policy. In particular, exhibitors should
+      not use sexualized images, activities, or other material. Booth staff
+      (including volunteers) should not use sexualized
+      clothing/uniforms/costumes, or otherwise create a sexualized environment.
+      ### Weapons Policy No weapons are allowed at DjangoCon US. Weapons include
+      but are not limited to explosives (including fireworks), guns, and large
+      knives such as those used for hunting or display, as well as any other
+      item used for the purpose of causing injury or harm to others. Anyone seen
+      in possession of one of these items will be asked to leave immediately,
+      and will only be allowed to return without the weapon. ### Photography In
+      order to make DjangoCon US {{ site.conf_year }} a great experience for
+      everyone, do not photograph, video, or audio record anyone at DjangoCon US
+      without their express permission, sought in advance. If someone does not
+      want to be photographed, video or audio recorded, please respect their
+      wishes. Crowd shots are permitted, but when only the faces of a few people
+      are visible, permission should be sought from all of those individuals.
+      _If a participant engages in behavior that violates this code of conduct,
+      the conference organizers may take any action they deem appropriate,
+      including warning the offender or expulsion from the conference with no
+      refund._ ## License This Code of Conduct was forked from the example
+      policy from the [Geek Feminism
+      wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy),
+      created by the Ada Initiative and other volunteers, which is under a
+      Creative Commons Zero license. This Code of Conduct also incorporates
+      portions from PyCon's Code of Conduct, which is licensed under the
+      [Creative Commons Attribution-ShareAlike 3.0 Unported
+      License](https://creativecommons.org/licenses/by-sa/3.0/). DjangoCon US
+      [Conference Code of Conduct](/conduct/) is licensed under a [Creative
+      Commons Attribution 3.0 Unported
+      License](http://creativecommons.org/licenses/by/3.0/). {% endmarkdown %}
     </div>
   </div>
 </div>

--- a/src/about/conduct.html
+++ b/src/about/conduct.html
@@ -112,7 +112,7 @@ This list is not an exhaustive list of all inappropriate behavior that is unacce
 
 ### General Reporting Procedure
 
-The best way to contact the DjangoCon Code of Conduct committee is by emailing [{{site.conduct_email}}](mailto:{{site.conduct_email}})
+The best way to contact the DjangoCon US Code of Conduct committee is by emailing [{{site.conduct_email}}](mailto:{{site.conduct_email}})
 
 ### Report Data
 
@@ -180,7 +180,7 @@ No weapons are allowed at DjangoCon US. Weapons include but are not limited to e
 
 ### Photography
 
-In order to make DjangoCon US {{ site.conf_year }} a great experience for everyone, do not photograph, video, or audio record anyone at DjangoCon without their express permission, sought in advance. If someone does not want to be photographed, video or audio recorded, please respect their wishes.
+In order to make DjangoCon US {{ site.conf_year }} a great experience for everyone, do not photograph, video, or audio record anyone at DjangoCon US without their express permission, sought in advance. If someone does not want to be photographed, video or audio recorded, please respect their wishes.
 
 Crowd shots are permitted, but when only the faces of a few people are visible, permission should be sought from all of those individuals.
 

--- a/src/about/conduct.html
+++ b/src/about/conduct.html
@@ -8,51 +8,29 @@ redirect_from: /coc/
 hero_graphic: /assets/img/2026/conduct.svg
 ---
 
-{% layout "_layouts/page.html" %} {% block hero_content %}
-<p class="prose">
-  DjangoCon US is dedicated to providing a fun harassment-free conference
-  experience for everyone, regardless of gender, gender identity, sexual
-  orientation, disability, physical appearance, body size, race, or religion.
-</p>
-{% endblock %} {% block wrapper %}
+{% layout "_layouts/page.html" %}
+
+{% block hero_content %}
+  <p class="prose">
+    DjangoCon US is dedicated to providing a fun harassment-free conference experience for everyone, regardless of gender, gender identity, sexual orientation, disability, physical appearance, body size, race, or religion.
+  </p>
+{% endblock %}
+
+{% block wrapper %}
 <section>
   <div class="wrapper">
     <div class="banner">
       <div>
-        <p>
-          Be kind to others. Do not insult or put down other attendees. Behave
-          professionally. Remember that harassment and sexist, racist, or
-          exclusionary jokes are not appropriate for DjangoCon US.
-        </p>
-        <p>
-          Attendees violating these rules may be asked to leave the conference
-          without a refund at the sole discretion of the conference organizers.
-        </p>
-        <p>
-          Thank you for helping make this a welcoming, friendly event for all.
-        </p>
+        <p>Be kind to others. Do not insult or put down other attendees. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for DjangoCon US.</p>
+        <p>Attendees violating these rules may be asked to leave the conference without a refund at the sole discretion of the conference organizers.</p>
+        <p>Thank you for helping make this a welcoming, friendly event for all.</p>
       </div>
 
       <aside class="bg-white">
         <p class="site-h3">Need help?</p>
 
-        <p>
-          If you are being harassed, notice that someone else is being harassed,
-          or have any other concerns, please contact the conference Code of
-          Conduct committee at
-          <a href="mailto:{{ site.conduct_email }}" class="link"
-            >{{ site.conduct_email }}</a
-          >{% comment %} or
-          <a href="tel:201-899-4189" class="link">201-899-4189</a>{% endcomment
-          %}.
-        </p>
-        <p>
-          To ensure we receive all the necessary information, please refer to
-          our
-          <a href="#procedures-for-reporting-incidents" class="link"
-            >Procedures for Reporting Incidents</a
-          >.
-        </p>
+        <p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact the conference Code of Conduct committee at <a href="mailto:{{ site.conduct_email }}" class="link">{{ site.conduct_email }}</a>{% comment %} or <a href="tel:201-899-4189" class="link">201-899-4189</a>{% endcomment %}.</p>
+        <p>To ensure we receive all the necessary information, please refer to our <a href="#procedures-for-reporting-incidents" class="link">Procedures for Reporting Incidents</a>.</p>
       </aside>
     </div>
   </div>
@@ -62,15 +40,13 @@ hero_graphic: /assets/img/2026/conduct.svg
   <div class="wrapper">
     <div class="grid-1-2">
       <section class="prose">
-        {% markdown %} ## Important Numbers Conference staff will be happy to
-        help participants contact venue security or local law enforcement,
-        provide escorts, or otherwise assist those experiencing harassment to
-        feel safe for the duration of the conference. We value your attendance.
-        If your physical safety or the physical safety of others is at risk,
-        please dial 911. If you are outside of Chicago, or on a cell phone, and
-        need to access Chicago's 911 services, dial [(312)
-        746-6000](tel:+1-312-746-6000). For other needs, contact the relevant
-        authorities below. {% endmarkdown %}
+{% markdown %}
+## Important Numbers
+
+Conference staff will be happy to help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+
+If your physical safety or the physical safety of others is at risk, please dial 911. If you are outside of Chicago, or on a cell phone, and need to access Chicago's 911 services, dial [(312) 746-6000](tel:+1-312-746-6000). For other needs, contact the relevant authorities below.
+{% endmarkdown %}
       </section>
 
       <section class="prose">
@@ -90,34 +66,13 @@ hero_graphic: /assets/img/2026/conduct.svg
     <section class="prose max-w-none mt-6">
       <h2 class="site-h3">Local authorities</h2>
 
-      <ul
-        class="gap-2 list-disc lg:gap-12 md:columns-2 lg:columns-3 *:break-inside-avoid max-w-none"
-      >
+      <ul class="gap-2 list-disc lg:gap-12 md:columns-2 lg:columns-3 *:break-inside-avoid max-w-none">
         <li>Emergency: 911</li>
         <li>Chicago Police Helpline: <a href="tel:311">311</a></li>
-        <li>
-          Chicago Police (Non-Emergency):
-          <a href="tel:+1-312-746-6000">(312) 746-6000</a>
-        </li>
-        <li>
-          Crime Check (to report Non-Emergency incidents):
-          <a href="https://www.chicagopolice.org/online-crime-reporting/"
-            >chicagopolice.org/online-crime-reporting</a
-          >
-        </li>
-        <li>
-          Sexual Assault Crisis Line/Victims Crisis Line (24 hours):
-          <a href="tel:+1-888-293-2080">(888) 293-2080</a>
-        </li>
-        <li>
-          Nearest Hospital:
-          <a href="https://maps.app.goo.gl/1YUMVFSdwZndiHMj9"
-            >John H. Stroger, Jr. Hospital of Cook County</a
-          >
-          1969 W Ogden Ave, Chicago, IL 60612<br /><a href="tel:+1-312-864-6000"
-            >(312) 864-6000</a
-          >
-        </li>
+        <li>Chicago Police (Non-Emergency): <a href="tel:+1-312-746-6000">(312) 746-6000</a></li>
+        <li>Crime Check (to report Non-Emergency incidents): <a href="https://www.chicagopolice.org/online-crime-reporting/">chicagopolice.org/online-crime-reporting</a></li>
+        <li>Sexual Assault Crisis Line/Victims Crisis Line (24 hours): <a href="tel:+1-888-293-2080">(888) 293-2080</a></li>
+        <li>Nearest Hospital: <a href="https://maps.app.goo.gl/1YUMVFSdwZndiHMj9">John H. Stroger, Jr. Hospital of Cook County</a> 1969 W Ogden Ave, Chicago, IL 60612<br /><a href="tel:+1-312-864-6000">(312) 864-6000</a></li>
       </ul>
     </section>
   </div>
@@ -126,57 +81,61 @@ hero_graphic: /assets/img/2026/conduct.svg
 <div class="block-container">
   <div class="wrapper">
     <div class="prose mx-auto">
-      {% markdown %} ## Procedures for Reporting Incidents If you believe
-      someone has violated the Code of Conduct, we encourage you to report it.
-      If you are unsure whether the incident is a violation, or whether the
-      space where it happened is covered by the Code of Conduct, we encourage
-      you to still report it. We are fine with receiving reports where we decide
-      to take no action for the sake of creating a safer space. ### Examples of
-      Inappropriate Behavior - Harassment of any participants in any form -
-      Deliberate intimidation, stalking, or following - Logging or taking
-      screenshots of online activity for harassment purposes - Publishing
-      others' private information, such as a physical or electronic address,
-      without explicit permission - Violent threats or language directed against
-      another person - Incitement of violence or harassment towards any
-      individual, including encouraging a person to commit suicide or to engage
-      in self-harm - Creating additional online accounts in order to harass
-      another person or circumvent a ban - Sexual language and imagery in online
-      communities or in any conference venue, including talks - Insults, put
-      downs, or jokes that are based upon stereotypes, that are exclusionary, or
-      that hold others up for ridicule - Excessive swearing - Unwelcome sexual
-      attention or advances - Unwelcome physical contact, including simulated
-      physical contact (eg, textual descriptions like "hug" or "backrub")
-      without consent or after a request to stop - Pattern of inappropriate
-      social contact, such as requesting/assuming inappropriate levels of
-      intimacy with others - Sustained disruption of online community
-      discussions, in-person presentations, or other in-person events -
-      Continued one-on-one communication after requests to cease - Other conduct
-      that is inappropriate for a professional audience including people of many
-      different backgrounds This list is not an exhaustive list of all
-      inappropriate behavior that is unacceptable at DjangoCon US. ### General
-      Reporting Procedure The best way to contact the DjangoCon US Code of
-      Conduct committee is by emailing
-      [{{site.conduct_email}}](mailto:{{site.conduct_email}}) ### Report Data
-      When you make a report via email or phone, please include: - Your contact
-      info (so we can get in touch with you if we need to follow up) - Date and
-      time of the incident - Location of incident - Whether the incident is
-      ongoing - Description of the incident - Identifying information of the
-      reported person: name, physical appearance, height, clothing, voice
-      accent, identifying badge information such as company name, ribbons, or
-      badge number - Additional circumstances surrounding the incident - Other
-      people involved in or witnesses to the incident and their contact
-      information or description Please provide as much information as possible.
-      You will receive feedback promptly or within 24 hours after submitting the
-      report. ### Confidentiality All reports will be kept confidential. When we
-      discuss incidents with people who are reported, we will anonymize details
-      as much as we can to protect reporter privacy. However, some incidents
-      happen in one-on-one interactions, and even if the details are anonymized,
-      the reported person may be able to guess who made the report. If you have
-      concerns about retaliation or your personal safety, please note those in
-      your report. We still encourage you to report, so that we can support you
-      while keeping our conference attendees safe. In some cases, we can compile
-      several anonymized reports into a pattern of behavior, and take action on
-      that pattern. {% endmarkdown %}
+{% markdown %}
+## Procedures for Reporting Incidents
+
+If you believe someone has violated the Code of Conduct, we encourage you to report it.
+
+If you are unsure whether the incident is a violation, or whether the space where it happened is covered by the Code of Conduct, we encourage you to still report it.
+
+We are fine with receiving reports where we decide to take no action for the sake of creating a safer space.
+
+### Examples of Inappropriate Behavior
+-   Harassment of any participants in any form
+-   Deliberate intimidation, stalking, or following
+-   Logging or taking screenshots of online activity for harassment purposes
+-   Publishing others' private information, such as a physical or electronic address, without explicit permission
+-   Violent threats or language directed against another person
+-   Incitement of violence or harassment towards any individual, including encouraging a person to commit suicide or to engage in self-harm
+-   Creating additional online accounts in order to harass another person or circumvent a ban
+-   Sexual language and imagery in online communities or in any conference venue, including talks
+-   Insults, put downs, or jokes that are based upon stereotypes, that are exclusionary, or that hold others up for ridicule
+-   Excessive swearing
+-   Unwelcome sexual attention or advances
+-   Unwelcome physical contact, including simulated physical contact (eg, textual descriptions like "hug" or "backrub") without consent or after a request to stop
+-   Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
+-   Sustained disruption of online community discussions, in-person presentations, or other in-person events
+-   Continued one-on-one communication after requests to cease
+-   Other conduct that is inappropriate for a professional audience including people of many different backgrounds
+
+This list is not an exhaustive list of all inappropriate behavior that is unacceptable at DjangoCon US.
+
+### General Reporting Procedure
+
+The best way to contact the DjangoCon Code of Conduct committee is by emailing [{{site.conduct_email}}](mailto:{{site.conduct_email}})
+
+### Report Data
+
+When you make a report via email or phone, please include:
+- Your contact info (so we can get in touch with you if we need to follow up)
+- Date and time of the incident
+- Location of incident
+- Whether the incident is ongoing
+- Description of the incident
+- Identifying information of the reported person: name, physical appearance, height, clothing, voice accent, identifying badge information such as company name, ribbons, or badge number
+- Additional circumstances surrounding the incident
+- Other people involved in or witnesses to the incident and their contact information or description
+
+Please provide as much information as possible.
+
+You will receive feedback promptly or within 24 hours after submitting the report.
+
+### Confidentiality
+
+All reports will be kept confidential. When we discuss incidents with people who are reported, we will anonymize details as much as we can to protect reporter privacy.
+
+However, some incidents happen in one-on-one interactions, and even if the details are anonymized, the reported person may be able to guess who made the report. If you have concerns about retaliation or your personal safety, please note those in your report. We still encourage you to report, so that we can support you while keeping our conference attendees safe. In some cases, we can compile several anonymized reports into a pattern of behavior, and take action on that pattern.
+{% endmarkdown %}
     </div>
   </div>
 </div>
@@ -184,72 +143,57 @@ hero_graphic: /assets/img/2026/conduct.svg
 <div class="bg-background block-container">
   <div class="wrapper">
     <div class="prose mx-auto">
-      {% markdown %} ## Full Code of Conduct _To make clear what is expected,
-      all delegates/attendees, speakers, exhibitors, organizers and volunteers
-      at any DjangoCon US event are required to conform to the following Code of
-      Conduct. Organizers will enforce this code throughout the event._ ### What
-      the conference is DjangoCon US is a community conference intended for
-      networking and collaboration in the developer community. We value the
-      participation of each member of the Django community and want all
-      attendees to have an enjoyable and fulfilling experience. Accordingly, all
-      attendees are expected to show respect and courtesy to other attendees
-      throughout the conference, at all conference events, and in all conference
-      online spaces (such as Slack), whether officially sponsored by DjangoCon
-      US or not. ### Be Kind To Others Do not insult or put down other
-      attendees. Behave professionally. Remember that harassment and sexist,
-      racist, or exclusionary jokes are not appropriate for DjangoCon US.
-      Attendees violating these rules may be asked to leave the conference
-      without a refund at the sole discretion of the conference organizers. ###
-      Be Respectful Not all of us will agree all the time, but disagreement is
-      no excuse for poor behavior and poor manners. We do not tolerate
-      harassment of conference participants in any form. Harassment includes:
-      offensive verbal comments related to gender, gender identity, sexual
-      orientation, disability, physical appearance, body size, race, religion;
-      sexual images in public spaces; deliberate intimidation, stalking, or
-      following; harassing photography or recording; sustained disruption of
-      talks or other events; repeated or inappropriate direct messaging on
-      conference or social media platforms; inappropriate physical contact; and
-      unwelcome sexual attention. ### Choose Your Words Be careful in the words
-      that you choose. Remember that sexist, racist, and other exclusionary
-      jokes can be offensive to those around you. Excessive swearing and
-      offensive jokes are not appropriate for DjangoCon US. We are all adults,
-      capable of having adult conversations. Preface your presentation with
-      appropriate Trigger/Content Warnings, if necessary. All communication
-      should be appropriate for a professional audience including people of many
-      different backgrounds. Sexual language and imagery is not appropriate for
-      any conference venue, including talks. Participants asked to stop any
-      harassing behavior are expected to comply immediately. Exhibitors in the
-      expo hall, sponsor or vendor booths, or similar activities are also
-      subject to the anti-harassment policy. In particular, exhibitors should
-      not use sexualized images, activities, or other material. Booth staff
-      (including volunteers) should not use sexualized
-      clothing/uniforms/costumes, or otherwise create a sexualized environment.
-      ### Weapons Policy No weapons are allowed at DjangoCon US. Weapons include
-      but are not limited to explosives (including fireworks), guns, and large
-      knives such as those used for hunting or display, as well as any other
-      item used for the purpose of causing injury or harm to others. Anyone seen
-      in possession of one of these items will be asked to leave immediately,
-      and will only be allowed to return without the weapon. ### Photography In
-      order to make DjangoCon US {{ site.conf_year }} a great experience for
-      everyone, do not photograph, video, or audio record anyone at DjangoCon US
-      without their express permission, sought in advance. If someone does not
-      want to be photographed, video or audio recorded, please respect their
-      wishes. Crowd shots are permitted, but when only the faces of a few people
-      are visible, permission should be sought from all of those individuals.
-      _If a participant engages in behavior that violates this code of conduct,
-      the conference organizers may take any action they deem appropriate,
-      including warning the offender or expulsion from the conference with no
-      refund._ ## License This Code of Conduct was forked from the example
-      policy from the [Geek Feminism
-      wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy),
-      created by the Ada Initiative and other volunteers, which is under a
-      Creative Commons Zero license. This Code of Conduct also incorporates
-      portions from PyCon's Code of Conduct, which is licensed under the
-      [Creative Commons Attribution-ShareAlike 3.0 Unported
-      License](https://creativecommons.org/licenses/by-sa/3.0/). DjangoCon US
-      [Conference Code of Conduct](/conduct/) is licensed under a [Creative
-      Commons Attribution 3.0 Unported
-      License](http://creativecommons.org/licenses/by/3.0/). {% endmarkdown %}
+{% markdown %}
+## Full Code of Conduct
+
+_To make clear what is expected, all delegates/attendees, speakers, exhibitors, organizers and volunteers at any DjangoCon US event are required to conform to the following Code of Conduct. Organizers will enforce this code throughout the event._
+
+### What the conference is
+
+DjangoCon US is a community conference intended for networking and collaboration in the developer community.
+
+We value the participation of each member of the Django community and want all attendees to have an enjoyable and fulfilling experience. Accordingly, all attendees are expected to show respect and courtesy to other attendees throughout the conference, at all conference events, and in all conference online spaces (such as Slack), whether officially sponsored by DjangoCon US or not.
+
+### Be Kind To Others
+
+Do not insult or put down other attendees. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for DjangoCon US. Attendees violating these rules may be asked to leave the conference without a refund at the sole discretion of the conference organizers.
+
+### Be Respectful
+
+Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We do not tolerate harassment of conference participants in any form.
+
+Harassment includes: offensive verbal comments related to gender, gender identity, sexual orientation, disability, physical appearance, body size, race, religion; sexual images in public spaces; deliberate intimidation, stalking, or following; harassing photography or recording; sustained disruption of talks or other events; repeated or inappropriate direct messaging on conference or social media platforms; inappropriate physical contact; and unwelcome sexual attention.
+
+### Choose Your Words
+
+Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Excessive swearing and offensive jokes are not appropriate for DjangoCon US. We are all adults, capable of having adult conversations. Preface your presentation with appropriate Trigger/Content Warnings, if necessary.
+
+All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery is not appropriate for any conference venue, including talks.
+
+Participants asked to stop any harassing behavior are expected to comply immediately.
+
+Exhibitors in the expo hall, sponsor or vendor booths, or similar activities are also subject to the anti-harassment policy. In particular, exhibitors should not use sexualized images, activities, or other material. Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.
+
+### Weapons Policy
+
+No weapons are allowed at DjangoCon US. Weapons include but are not limited to explosives (including fireworks), guns, and large knives such as those used for hunting or display, as well as any other item used for the purpose of causing injury or harm to others. Anyone seen in possession of one of these items will be asked to leave immediately, and will only be allowed to return without the weapon.
+
+### Photography
+
+In order to make DjangoCon US {{ site.conf_year }} a great experience for everyone, do not photograph, video, or audio record anyone at DjangoCon without their express permission, sought in advance. If someone does not want to be photographed, video or audio recorded, please respect their wishes.
+
+Crowd shots are permitted, but when only the faces of a few people are visible, permission should be sought from all of those individuals.
+
+_If a participant engages in behavior that violates this code of conduct, the conference organizers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund._
+
+## License
+
+This Code of Conduct was forked from the example policy from the [Geek Feminism wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy), created by the Ada Initiative and other volunteers, which is under a Creative Commons Zero license.
+
+This Code of Conduct also incorporates portions from PyCon's Code of Conduct, which is licensed under the [Creative Commons Attribution-ShareAlike 3.0 Unported License](https://creativecommons.org/licenses/by-sa/3.0/).
+
+DjangoCon US [Conference Code of Conduct](/conduct/) is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/).
+{% endmarkdown %}
     </div>
   </div>
 </div>


### PR DESCRIPTION
I updated a few instances of DjangoCon to have 'US' on the conduct page.

Note that my original commit reformatted much of the page using a linter, so I rolled that back and then just edited the necessary text.