### PR TITLE
Fix DEFNA sponsor link label to defna.org

### DIFF
--- a/src/_content/sponsors/defna.md
+++ b/src/_content/sponsors/defna.md
@@ -8,5 +8,5 @@ logo:
 hiring_url: false
 url:
     target: 'https://defna.org/'
-    label: defna.com
+    label: defna.org
 ---


### PR DESCRIPTION
The DEFNA sponsor entry displayed `defna.com` as its link label while the actual URL already points to `https://defna.org/`. Updates the label to match the correct `.org` domain.