### PR TITLE
Open spaces: second column beside the talks

### DIFF
--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -119,27 +119,60 @@ module.exports = function(config, timezone = 'UTC') {
   }
 
   config.addCollection("sessionsByDateAndTime", function(collectionApi) {
-    const sorted = buildSortedSlots(collectionApi);
+    return buildSortedSlots(collectionApi);
+  });
 
-    // Attach each open space to its nearest slot so the mobile layout (which
-    // can't span rows) can render it inline right after that slot's talks.
+  // A single chronologically ordered list per date, mixing talk slots and open
+  // spaces as peers. The desktop grid can't use this (it needs open spaces in
+  // their own column, spanning rows), but the mobile layout is one column, so
+  // it renders straight down this list and everything lands in true time order.
+  // Each row is { type: "slot" | "space", start, end } plus the payload.
+  config.addCollection("scheduleRowsByDate", function(collectionApi) {
+    const slotsByDate = buildSortedSlots(collectionApi);
+
+    const byDate = {};
+    for (let date in slotsByDate) {
+      byDate[date] = slotsByDate[date].map(slot => ({
+        type: 'slot',
+        start: slot.start,
+        end: slot.end,
+        startMs: parseISO(slot.start).getTime(),
+        endMs: parseISO(slot.end).getTime(),
+        slot,
+      }));
+    }
+
     loadOpenSpaces().forEach(space => {
       const startObj = parseDateTime(space.start_datetime, timezone);
       const endObj = parseDateTime(space.end_datetime, timezone);
       const date = format(startObj, 'yyyy-MM-dd');
+      const start = format(startObj, "yyyy-MM-dd'T'HH:mm:ssXXX");
+      const end = format(endObj, "yyyy-MM-dd'T'HH:mm:ssXXX");
 
-      const slots = sorted[date];
-      if (!slots || slots.length === 0) return;
-
-      const slot = slots[nearestIndex(slots, startObj.getTime())];
-      if (!slot.openSpaces) slot.openSpaces = [];
-      slot.openSpaces.push(Object.assign({}, space, {
-        start: format(startObj, "yyyy-MM-dd'T'HH:mm:ssXXX"),
-        end: format(endObj, "yyyy-MM-dd'T'HH:mm:ssXXX"),
-      }));
+      if (!byDate[date]) byDate[date] = [];
+      byDate[date].push({
+        type: 'space',
+        start,
+        end,
+        startMs: startObj.getTime(),
+        endMs: endObj.getTime(),
+        space: Object.assign({}, space, { start, end }),
+      });
     });
 
-    return sorted;
+    for (let date in byDate) {
+      // Strict chronological order. On an exact start/end tie a talk slot wins,
+      // so concurrent talks stay the primary thing you read first.
+      byDate[date].sort((a, b) => {
+        if (a.startMs !== b.startMs) return a.startMs - b.startMs;
+        if (a.endMs !== b.endMs) return a.endMs - b.endMs;
+        if (a.type === b.type) return 0;
+        return a.type === 'slot' ? -1 : 1;
+      });
+      byDate[date].forEach(row => { delete row.startMs; delete row.endMs; });
+    }
+
+    return byDate;
   });
 
   // Open spaces (track "t1") grouped by date, each carrying the CSS grid rows

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -15,25 +15,30 @@ function parseDateTime(raw, timezone) {
 }
 
 module.exports = function(config, timezone = 'UTC') {
-  config.addCollection("sessionsByDateAndTime", function(collectionApi) {
+  const HEADER_ROWS = 0; // no reserved header row; slots start on grid row 1
+
+  // Build the date -> [slots] structure for the talk/break/etc. track (t0),
+  // excluding open spaces (t1). Shared by both the schedule grid and the
+  // open-space row-span math so the two always agree on slot ordering.
+  function buildSortedSlots(collectionApi) {
     let sessions = collectionApi.getFilteredByGlob("src/_content/schedule/{tutorials,talks,sprints}/*.md");
 
-    if (sessions.length === 0) return [];
+    if (sessions.length === 0) return {};
 
     const manualContent = fs.readFileSync('src/_content/schedule/manual.yaml', 'utf8');
-    const manualData = yaml.parse(manualContent);
+    const manualData = yaml.parse(manualContent) || [];
     sessions = sessions.concat(manualData);
 
-    sessions = sessions.filter(session => !(session.data?.hidden || session.hidden));
+    sessions = sessions.filter(session => {
+      const data = session.data || session;
+      return !(data.hidden || session.hidden) && data.track !== 't1';
+    });
 
     const sessionsByDateAndTime = sessions.reduce((acc, session) => {
       const sessionData = session.data || session;
 
-      const startRaw = sessionData.start_datetime;
-      const endRaw = sessionData.end_datetime;
-
-      const startDateObj = parseDateTime(startRaw, timezone);
-      const endDateObj = parseDateTime(endRaw, timezone);
+      const startDateObj = parseDateTime(sessionData.start_datetime, timezone);
+      const endDateObj = parseDateTime(sessionData.end_datetime, timezone);
 
       const startDate = format(startDateObj, 'yyyy-MM-dd');
       const start = format(startDateObj, "yyyy-MM-dd'T'HH:mm:ssXXX");
@@ -47,11 +52,7 @@ module.exports = function(config, timezone = 'UTC') {
       let slot = acc[startDate].find(slot => `${slot.start}-${slot.end}` === slotKey);
 
       if (!slot) {
-        slot = {
-          start: start,
-          end: end,
-          sessions: []
-        };
+        slot = { start: start, end: end, sessions: [] };
         acc[startDate].push(slot);
       }
 
@@ -99,6 +100,109 @@ module.exports = function(config, timezone = 'UTC') {
     }
 
     return sortedSessionsByDateAndTime;
+  }
+
+  function loadOpenSpaces() {
+    const manualContent = fs.readFileSync('src/_content/schedule/manual.yaml', 'utf8');
+    const manualData = yaml.parse(manualContent) || [];
+    return manualData.filter(space => space.track === 't1' && !space.hidden);
+  }
+
+  function nearestIndex(slots, ms) {
+    let idx = 0;
+    let best = Infinity;
+    slots.forEach((slot, i) => {
+      const diff = Math.abs(new Date(slot.start).getTime() - ms);
+      if (diff < best) { best = diff; idx = i; }
+    });
+    return idx;
+  }
+
+  config.addCollection("sessionsByDateAndTime", function(collectionApi) {
+    const sorted = buildSortedSlots(collectionApi);
+
+    // Attach each open space to its nearest slot so the mobile layout (which
+    // can't span rows) can render it inline right after that slot's talks.
+    loadOpenSpaces().forEach(space => {
+      const startObj = parseDateTime(space.start_datetime, timezone);
+      const endObj = parseDateTime(space.end_datetime, timezone);
+      const date = format(startObj, 'yyyy-MM-dd');
+
+      const slots = sorted[date];
+      if (!slots || slots.length === 0) return;
+
+      const slot = slots[nearestIndex(slots, startObj.getTime())];
+      if (!slot.openSpaces) slot.openSpaces = [];
+      slot.openSpaces.push(Object.assign({}, space, {
+        start: format(startObj, "yyyy-MM-dd'T'HH:mm:ssXXX"),
+        end: format(endObj, "yyyy-MM-dd'T'HH:mm:ssXXX"),
+      }));
+    });
+
+    return sorted;
+  });
+
+  // Open spaces (track "t1") grouped by date, each carrying the CSS grid rows
+  // it should span. An open space covers every talk slot it overlaps in time,
+  // so on desktop it renders as one tall block beside those talks. Row math:
+  // grid row 1 is the column header, slot k (0-based) lives on grid row k + 2.
+  config.addCollection("openSpacesByDate", function(collectionApi) {
+    const slotsByDate = buildSortedSlots(collectionApi);
+
+    const byDate = {};
+    loadOpenSpaces().forEach(space => {
+      const startObj = parseDateTime(space.start_datetime, timezone);
+      const endObj = parseDateTime(space.end_datetime, timezone);
+      const date = format(startObj, 'yyyy-MM-dd');
+
+      const entry = Object.assign({}, space, {
+        date,
+        startMs: startObj.getTime(),
+        endMs: endObj.getTime(),
+        start: format(startObj, "yyyy-MM-dd'T'HH:mm:ssXXX"),
+        end: format(endObj, "yyyy-MM-dd'T'HH:mm:ssXXX"),
+      });
+
+      if (!byDate[date]) byDate[date] = [];
+      byDate[date].push(entry);
+    });
+
+    for (let date in byDate) {
+      const spaces = byDate[date].sort((a, b) => a.startMs - b.startMs);
+      const slots = slotsByDate[date] || [];
+
+      spaces.forEach((space, i) => {
+        if (slots.length === 0) {
+          space.rowStart = HEADER_ROWS + 1;
+          space.rowEnd = HEADER_ROWS + 2;
+          return;
+        }
+
+        // Anchor to the slot nearest the open space's start, then extend down
+        // to the last slot that begins before the open space ends.
+        const startIdx = nearestIndex(slots, space.startMs);
+        let endIdx = startIdx;
+        slots.forEach((slot, idx) => {
+          if (new Date(slot.start).getTime() < space.endMs) {
+            endIdx = Math.max(endIdx, idx);
+          }
+        });
+
+        // Never bleed into the next open space's starting row.
+        const next = spaces[i + 1];
+        if (next) {
+          endIdx = Math.min(endIdx, nearestIndex(slots, next.startMs) - 1);
+        }
+        if (endIdx < startIdx) endIdx = startIdx;
+
+        space.rowStart = startIdx + HEADER_ROWS + 1;
+        space.rowEnd = endIdx + HEADER_ROWS + 2; // grid-row end line is exclusive
+      });
+
+      spaces.forEach(space => { delete space.startMs; delete space.endMs; });
+    }
+
+    return byDate;
   });
 
   config.addCollection("talks", function(collectionApi) {

--- a/src/_includes/open-space-card.html
+++ b/src/_includes/open-space-card.html
@@ -1,0 +1,15 @@
+{% comment %}
+  Renders a single open space card. Expects `space` in scope. Uses h-full so it
+  fills its container — on desktop that container is a multi-row grid cell, so
+  the card grows to span the full duration beside the concurrent talks.
+{% endcomment %}
+<section class="flex flex-col flex-1 h-full p-4 bg-white border-2 border-gray-300 rounded border-t-4" aria-label="Open space">
+  <p class="text-sm text-gray-500">
+    <time datetime="{{ space.start }}">{{ space.start | formatDateTime: "h:mm aaa" }}</time> to
+    <time datetime="{{ space.end }}">{{ space.end | formatDateTime: "h:mm aaa" }}</time>
+  </p>
+  <h4 class="font-semibold leading-tight lg:text-lg">{{ space.title }}</h4>
+  {% if space.room %}
+    <p class="mt-1 text-sm">{{ space.room }}</p>
+  {% endif %}
+</section>

--- a/src/_includes/open-space-card.html
+++ b/src/_includes/open-space-card.html
@@ -1,15 +1,15 @@
 {% comment %}
   Renders a single open space card. Expects `space` in scope. Uses h-full so it
   fills its container — on desktop that container is a multi-row grid cell, so
-  the card grows to span the full duration beside the concurrent talks.
+  the card grows to span the full duration beside the concurrent talks. Times
+  are rendered by the caller, outside the card, as they are for talk slots.
 {% endcomment %}
 <section class="flex flex-col flex-1 h-full p-4 bg-white border-2 border-gray-300 rounded border-t-4" aria-label="Open space">
-  <p class="text-sm text-gray-500">
-    <time datetime="{{ space.start }}">{{ space.start | formatDateTime: "h:mm aaa" }}</time> to
-    <time datetime="{{ space.end }}">{{ space.end | formatDateTime: "h:mm aaa" }}</time>
-  </p>
-  <h4 class="font-semibold leading-tight lg:text-lg">{{ space.title }}</h4>
-  {% if space.room %}
-    <p class="mt-1 text-sm">{{ space.room }}</p>
-  {% endif %}
+  <header class="space-y-4">
+    {% if space.room %}
+      <p class="text-sm">{{ space.room }}</p>
+    {% endif %}
+
+    <h4 class="font-semibold leading-tight lg:text-lg">{{ space.title }}</h4>
+  </header>
 </section>

--- a/src/_includes/session-cards.html
+++ b/src/_includes/session-cards.html
@@ -1,0 +1,9 @@
+{% comment %}
+  Renders the talk/session cards for a single slot. Expects `slot` in scope.
+  Ideally up to 4 tracks, with some sessions spanning every track.
+{% endcomment %}
+{%- assign color_classes = "border-t-green,border-t-teal,border-t-cyan,border-t-orange" | split: "," %}
+{% for session in slot.sessions %}
+  {%- assign color = color_classes[forloop.index0 | modulo: color_classes.size] %}
+  {% include "session-card.html", session:session, color_class:color %}
+{% endfor %}

--- a/src/schedule.html
+++ b/src/schedule.html
@@ -93,12 +93,14 @@ days:
               {% endfor %}
 
               {% for space in open_spaces %}
-                <div class="flex flex-col gap-4 p-4 rounded-md bg-gray-100" style="grid-column: 3; grid-row: {{ space.rowStart }} / {{ space.rowEnd }};">
-                  <h3 class="font-medium text-gray-500 lg:text-lg">
+                <div class="flex flex-col" style="grid-column: 3; grid-row: {{ space.rowStart }} / {{ space.rowEnd }};">
+                  <h3 class="font-medium text-gray-500 lg:text-lg lg:py-6 lg:sticky lg:top-12">
                     <time datetime="{{ space.start }}">{{ space.start | formatDateTime: "h:mm aaa" }}</time> to
                     <time datetime="{{ space.end }}">{{ space.end | formatDateTime: "h:mm aaa" }}</time>
                   </h3>
-                  {% include "open-space-card.html", space:space %}
+                  <div class="flex flex-1 p-4 rounded-md bg-gray-100">
+                    {% include "open-space-card.html", space:space %}
+                  </div>
                 </div>
               {% endfor %}
             </div>
@@ -116,11 +118,13 @@ days:
                     {% include "session-cards.html", slot:slot %}
                   </ul>
                   {% for space in slot.openSpaces %}
-                    <div class="w-full">
-                      <h3 class="w-full pb-2 font-medium text-gray-500">
+                    <div class="w-full sticky top-[120px] bg-white pb-2 z-10">
+                      <h3 class="w-full font-medium text-gray-500">
                         <time datetime="{{ space.start }}">{{ space.start | formatDateTime: "h:mm aaa" }}</time> to
                         <time datetime="{{ space.end }}">{{ space.end | formatDateTime: "h:mm aaa" }}</time>
                       </h3>
+                    </div>
+                    <div class="w-full">
                       {% include "open-space-card.html", space:space %}
                     </div>
                   {% endfor %}

--- a/src/schedule.html
+++ b/src/schedule.html
@@ -73,9 +73,9 @@ days:
               space spans (grid-row start/end computed in lib/sessions.js) every
               talk row it overlaps, forming one tall block beside those talks.
 
-              Mobile: talks stack, with each open space rendered inline right
-              after the slot it starts nearest to (grids can't span cleanly in a
-              single column).
+              Mobile: one column in true chronological order — talk slots and
+              open spaces interleaved as peers, from collections.scheduleRowsByDate
+              (grids can't span cleanly in a single column, so no columns here).
             {% endcomment %}
 
             <div class="hidden mt-4 lg:grid lg:gap-x-8 lg:gap-y-8" style="grid-template-columns: 12rem minmax(0, 1fr) 18rem;">
@@ -108,28 +108,23 @@ days:
             </div>
 
             <div class="mt-4 space-y-8 lg:hidden">
-              {% for slot in day[1] %}
+              {% for row in collections.scheduleRowsByDate[date_key] %}
                 <div class="flex flex-wrap gap-4">
                   <div class="w-full sticky top-[120px] bg-white pb-2 z-10">
                     <h3 class="w-full font-medium text-gray-500">
-                      <time datetime="{{ slot.start }}">{{ slot.start | formatDateTime: "h:mm aaa" }}</time> to
-                      <time datetime="{{ slot.end }}">{{ slot.end | formatDateTime: "h:mm aaa" }}</time>
+                      <time datetime="{{ row.start }}">{{ row.start | formatDateTime: "h:mm aaa" }}</time> to
+                      <time datetime="{{ row.end }}">{{ row.end | formatDateTime: "h:mm aaa" }}</time>
                     </h3>
                   </div>
-                  <ul class="flex flex-row flex-wrap flex-1 gap-4 rounded-md">
-                    {% include "session-cards.html", slot:slot %}
-                  </ul>
-                  {% for space in slot.openSpaces %}
-                    <div class="w-full sticky top-[120px] bg-white pb-2 z-10">
-                      <h3 class="w-full font-medium text-gray-500">
-                        <time datetime="{{ space.start }}">{{ space.start | formatDateTime: "h:mm aaa" }}</time> to
-                        <time datetime="{{ space.end }}">{{ space.end | formatDateTime: "h:mm aaa" }}</time>
-                      </h3>
-                    </div>
+                  {% if row.type == "space" %}
                     <div class="w-full">
-                      {% include "open-space-card.html", space:space %}
+                      {% include "open-space-card.html", space:row.space %}
                     </div>
-                  {% endfor %}
+                  {% else %}
+                    <ul class="flex flex-row flex-wrap flex-1 gap-4 rounded-md">
+                      {% include "session-cards.html", slot:row.slot %}
+                    </ul>
+                  {% endif %}
                 </div>
               {% endfor %}
             </div>

--- a/src/schedule.html
+++ b/src/schedule.html
@@ -93,7 +93,11 @@ days:
               {% endfor %}
 
               {% for space in open_spaces %}
-                <div class="flex p-4 rounded-md bg-gray-100" style="grid-column: 3; grid-row: {{ space.rowStart }} / {{ space.rowEnd }};">
+                <div class="flex flex-col gap-4 p-4 rounded-md bg-gray-100" style="grid-column: 3; grid-row: {{ space.rowStart }} / {{ space.rowEnd }};">
+                  <h3 class="font-medium text-gray-500 lg:text-lg">
+                    <time datetime="{{ space.start }}">{{ space.start | formatDateTime: "h:mm aaa" }}</time> to
+                    <time datetime="{{ space.end }}">{{ space.end | formatDateTime: "h:mm aaa" }}</time>
+                  </h3>
                   {% include "open-space-card.html", space:space %}
                 </div>
               {% endfor %}
@@ -113,6 +117,10 @@ days:
                   </ul>
                   {% for space in slot.openSpaces %}
                     <div class="w-full">
+                      <h3 class="w-full pb-2 font-medium text-gray-500">
+                        <time datetime="{{ space.start }}">{{ space.start | formatDateTime: "h:mm aaa" }}</time> to
+                        <time datetime="{{ space.end }}">{{ space.end | formatDateTime: "h:mm aaa" }}</time>
+                      </h3>
                       {% include "open-space-card.html", space:space %}
                     </div>
                   {% endfor %}

--- a/src/schedule.html
+++ b/src/schedule.html
@@ -62,33 +62,82 @@ days:
             {% endif %}
           </div>
 
-          <div class="mt-4 space-y-8">
+          {% assign date_key = day[0] | formatDateTime: 'yyyy-MM-dd' %}
+          {% assign open_spaces = collections.openSpacesByDate[date_key] %}
+
+          {% if open_spaces %}
             {% comment %}
-              Draw each time slot, e.g. 9:00 AM to 10:00 AM followed
+              Days with open spaces (Mon/Tue).
+
+              Desktop: a CSS grid where talks fill columns 1-2 and each open
+              space spans (grid-row start/end computed in lib/sessions.js) every
+              talk row it overlaps, forming one tall block beside those talks.
+
+              Mobile: talks stack, with each open space rendered inline right
+              after the slot it starts nearest to (grids can't span cleanly in a
+              single column).
             {% endcomment %}
-            {% for slot in day[1] %}
-              <div class="flex flex-wrap gap-4 lg:gap-8">
-                <div class="w-full md:w-48 sticky top-[120px] bg-white pb-2 z-10 lg:static lg:pt-6">
-                  <h3 class="w-full font-medium text-gray-500 lg:text-lg lg:py-6 lg:sticky lg:top-12 lg:text-right">
+
+            <div class="hidden mt-4 lg:grid lg:gap-x-8 lg:gap-y-8" style="grid-template-columns: 12rem minmax(0, 1fr) 18rem;">
+              {% for slot in day[1] %}
+                {% assign grid_row = forloop.index %}
+                <div style="grid-column: 1; grid-row: {{ grid_row }};">
+                  <h3 class="font-medium text-right text-gray-500 lg:text-lg lg:py-6 lg:sticky lg:top-12">
                     <time datetime="{{ slot.start }}">{{ slot.start | formatDateTime: "h:mm aaa" }}</time> to
                     <time datetime="{{ slot.end }}">{{ slot.end | formatDateTime: "h:mm aaa" }}</time>
                   </h3>
                 </div>
-                <ul
-                  class="flex flex-row flex-wrap flex-1 gap-4 rounded-md lg:p-4 lg:bg-gray-100">
-                  {% comment %}
-                    Ideally up to 4 tracks, with some sessions spanning every track
-                  {% endcomment %}
-
-                  {%- assign color_classes = "border-t-green,border-t-teal,border-t-cyan,border-t-orange" | split: "," %}
-                  {% for session in slot.sessions %}
-                    {%- assign color = color_classes[forloop.index0 | modulo: color_classes.size] %}
-                    {% include "session-card.html", session:session, color_class:color %}
-                  {% endfor %}
+                <ul class="flex flex-row flex-wrap gap-4 p-4 rounded-md bg-gray-100" style="grid-column: 2; grid-row: {{ grid_row }};">
+                  {% include "session-cards.html", slot:slot %}
                 </ul>
-              </div>
-            {% endfor %}
-          </div>
+              {% endfor %}
+
+              {% for space in open_spaces %}
+                <div class="flex p-4 rounded-md bg-gray-100" style="grid-column: 3; grid-row: {{ space.rowStart }} / {{ space.rowEnd }};">
+                  {% include "open-space-card.html", space:space %}
+                </div>
+              {% endfor %}
+            </div>
+
+            <div class="mt-4 space-y-8 lg:hidden">
+              {% for slot in day[1] %}
+                <div class="flex flex-wrap gap-4">
+                  <div class="w-full sticky top-[120px] bg-white pb-2 z-10">
+                    <h3 class="w-full font-medium text-gray-500">
+                      <time datetime="{{ slot.start }}">{{ slot.start | formatDateTime: "h:mm aaa" }}</time> to
+                      <time datetime="{{ slot.end }}">{{ slot.end | formatDateTime: "h:mm aaa" }}</time>
+                    </h3>
+                  </div>
+                  <ul class="flex flex-row flex-wrap flex-1 gap-4 rounded-md">
+                    {% include "session-cards.html", slot:slot %}
+                  </ul>
+                  {% for space in slot.openSpaces %}
+                    <div class="w-full">
+                      {% include "open-space-card.html", space:space %}
+                    </div>
+                  {% endfor %}
+                </div>
+              {% endfor %}
+            </div>
+
+          {% else %}
+            {% comment %} Days without open spaces: single-column time + talks. {% endcomment %}
+            <div class="mt-4 space-y-8">
+              {% for slot in day[1] %}
+                <div class="flex flex-wrap gap-4 lg:gap-8">
+                  <div class="w-full md:w-48 sticky top-[120px] bg-white pb-2 z-10 lg:static lg:pt-6">
+                    <h3 class="w-full font-medium text-gray-500 lg:text-lg lg:py-6 lg:sticky lg:top-12 lg:text-right">
+                      <time datetime="{{ slot.start }}">{{ slot.start | formatDateTime: "h:mm aaa" }}</time> to
+                      <time datetime="{{ slot.end }}">{{ slot.end | formatDateTime: "h:mm aaa" }}</time>
+                    </h3>
+                  </div>
+                  <ul class="flex flex-row flex-wrap flex-1 gap-4 rounded-md lg:p-4 lg:bg-gray-100">
+                    {% include "session-cards.html", slot:slot %}
+                  </ul>
+                </div>
+              {% endfor %}
+            </div>
+          {% endif %}
         </div>
       {% endfor %}
     </div>

--- a/src/schedule.html
+++ b/src/schedule.html
@@ -94,9 +94,11 @@ days:
 
               {% for space in open_spaces %}
                 <div class="flex flex-col" style="grid-column: 3; grid-row: {{ space.rowStart }} / {{ space.rowEnd }};">
-                  <h3 class="font-medium text-gray-500 lg:text-lg lg:py-6 lg:sticky lg:top-12">
-                    <time datetime="{{ space.start }}">{{ space.start | formatDateTime: "h:mm aaa" }}</time> to
-                    <time datetime="{{ space.end }}">{{ space.end | formatDateTime: "h:mm aaa" }}</time>
+                  <h3 class="font-medium text-gray-500 lg:text-lg lg:py-6 lg:sticky lg:top-12 lg:z-10">
+                    <span class="px-1 rounded-md bg-white">
+                      <time datetime="{{ space.start }}">{{ space.start | formatDateTime: "h:mm aaa" }}</time> to
+                      <time datetime="{{ space.end }}">{{ space.end | formatDateTime: "h:mm aaa" }}</time>
+                    </span>
                   </h3>
                   <div class="flex flex-1 p-4 rounded-md bg-gray-100">
                     {% include "open-space-card.html", space:space %}


### PR DESCRIPTION
Follow-up to #72.

Builds on the open-spaces data from #72 and changes how they render on the schedule: instead of interleaving as their own full-width rows (which threw off the talk alignment), open spaces now appear in a **second column beside the talks**.

### What it does
- **Desktop:** a CSS grid where each open space spans every talk row it overlaps in time, so it reads as one tall block next to the concurrent talks (e.g. the 11 am open space spans the 11:10 and 11:40 talks). Row spans are computed in `lib/sessions.js`.
- **Mobile:** open spaces stack inline right after the talk slot they start nearest (a single column can't span cleanly).
- Open spaces are pulled out of the main time-slot flow, so they no longer distort the talk rows.
- Each open space sits in the same `bg-gray-100` slot frame + bordered card as the talks, so both columns match.

### Notes
- Only days with open spaces (Mon/Tue) get the extra column; other days are unchanged.
- Alignment is intentionally approximate — an open space lines up with the talks happening around it, not to the exact minute.
- Adds `session-cards.html` / `open-space-card.html` includes to share markup across the layouts.

Targets \`add-open-spaces-to-schedule\` so it can land with / on top of #72.