### PR TITLE
Add mentions of sprint office hours to sprint blog posts.

### DIFF
--- a/src/_content/posts/contribution-sprints.md
+++ b/src/_content/posts/contribution-sprints.md
@@ -52,6 +52,14 @@ The "why" can vary. Maybe you don’t feel confident enough to contribute code (
 
 The "how" starts with identifying your strengths, then connecting with projects that might need them. Shauna’s video is a great starting point. Once you identify a project that interests you, reach out! Sometimes a project doesn’t realize what kind of help it needs until someone offers it.
 
+## Preparing for a Contribution Sprint
+
+We are hosting three office hour style events where people can drop in and get help configuring their machine. If you're a first-time contributor, consider attending one of these. To participate, you will need to **[join Django's Discord server](https://chat.djangoproject.com)** and attend the event on the `#welcome` voice channel.
+
+- [August 9th, 7am US/Chicago, 12pm UTC](https://time.is/compare/0700_9_August_2026_Chicago)
+- [August 9th, 6pm US/Chicago, 11pm UTC](https://time.is/compare/1800_9_August_2026_Chicago)
+- [August 11th, 10:30am US/Chicago, 3:30pm UTC](https://time.is/compare/1030_11_August_2026_Chicago)
+
 ## Preparing to Lead or Organize a Sprint
 
 If you’re a project maintainer or contributor, a bit of preparation can help make the most of the sprint and avoid burnout. Most open source maintainers are unpaid volunteers, we appreciate you.

--- a/src/_content/posts/sprints-prep.md
+++ b/src/_content/posts/sprints-prep.md
@@ -44,6 +44,12 @@ Getting involved with community discussions ahead of time will also give you ple
 
 One of the biggest time sinks during sprints is getting a project running for the first time. Rather than spending your first hour troubleshooting missing dependencies or waiting for packages to install, **try setting up your development environment before you arrive at the conference**.
 
+We are hosting three office hour style events where people can drop in and get help configuring their machine. If you're a first-time contributor, consider attending one of these. To participate, you will need to **[join Django's Discord server](https://chat.djangoproject.com)** and attend the event on the `#welcome` voice channel.
+
+- [August 9th, 7am US/Chicago, 12pm UTC](https://time.is/compare/0700_9_August_2026_Chicago)
+- [August 9th, 6pm US/Chicago, 11pm UTC](https://time.is/compare/1800_9_August_2026_Chicago)
+- [August 11th, 10:30am US/Chicago, 3:30pm UTC](https://time.is/compare/1030_11_August_2026_Chicago)
+
 Most projects have setup instructions in their documentation, so clone the repository, follow the installation steps, and make sure you can run the project locally. If you run into issues, don't panic; that's completely normal! You can ask questions in the project's communication channels before the conference or save them for the sprint itself. Having a head start means you'll be able to spend more time learning from maintainers, collaborating with other contributors, and making meaningful contributions instead of waiting for your environment to cooperate.
 
 ## Final Notes


### PR DESCRIPTION
## Update to the contribution sprints info guide blog post

<img width="781" height="353" alt="Screenshot from 2026-07-23 07-56-44" src="https://github.com/user-attachments/assets/6336e451-c225-4644-b0ab-5510881e751b" />

## Update to the preparing for contribution sprints blog post

<img width="776" height="593" alt="Screenshot from 2026-07-23 07-52-56" src="https://github.com/user-attachments/assets/7f248efd-c843-4a05-be3b-f8d47bbe0a43" />
