### PR TITLE
Add date card to landing page for sprint office hours.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -60,7 +60,7 @@ templateClass: homepage
               include 'date-card.html',
               month:"Aug",
               days:"9, 11",
-              heading:"<a href='/news/contribution-sprints/#preparing-for-a-contribution-sprint'>Sprint office hours: Get help getting set up</a>"
+              heading:'<a href="/news/contribution-sprints/#preparing-for-a-contribution-sprint">Sprint office hours: Get help getting set up</a>'
             %}
           </li>
           <li>
@@ -68,7 +68,7 @@ templateClass: homepage
               include 'date-card.html',
               month:"Aug",
               days:"24-26",
-              heading:"<a href='/schedule/'>Talks: Dozens of talks chosen by the community</a>"
+              heading:'<a href="/schedule/">Talks: Dozens of talks chosen by the community</a>'
             %}
           </li>
           <li>
@@ -76,7 +76,7 @@ templateClass: homepage
               include 'date-card.html',
               month:"Aug",
               days:"27-28",
-              heading:"<a href='/sprints/'>Sprints: Team up to work on Django!</a>"
+              heading:'<a href="/sprints/">Sprints: Team up to work on Django!</a>'
             %}
           </li>
         </ul>

--- a/src/index.html
+++ b/src/index.html
@@ -55,12 +55,20 @@ templateClass: homepage
         </section>
 
         <ul class="items-center self-end gap-6 py-4 text-left lg:gap-0 md:flex lg:flex-col lg:items-start">
-        <li>
+          <li>
+            {%
+              include 'date-card.html',
+              month:"Aug",
+              days:"9, 11",
+              heading:"<a href='/news/contribution-sprints/#preparing-for-a-contribution-sprint'>Sprint office hours: Get help getting set up</a>"
+            %}
+          </li>
+          <li>
             {%
               include 'date-card.html',
               month:"Aug",
               days:"24-26",
-              heading:"Talks: Dozens of talks chosen by the community"
+              heading:"<a href='/schedule/'>Talks: Dozens of talks chosen by the community</a>"
             %}
           </li>
           <li>


### PR DESCRIPTION
Requires #74 for the heading anchor tag to exist

This also adds a link for the talks date card to the schedule.

<img width="1191" height="405" alt="image" src="https://github.com/user-attachments/assets/1f21e266-3799-4505-b20c-954c902d0ee3" />


