### PR TITLE
📅 Shorten Tues/Wed opening remarks to unify break times

### DIFF
--- a/src/_content/schedule/manual.yaml
+++ b/src/_content/schedule/manual.yaml
@@ -88,10 +88,10 @@
   start_datetime: 2026-08-25 08:00:00-05:00
   title: Speaker Green Room
   track: t0
-- end_datetime: 2026-08-25 10:45:00-05:00
+- end_datetime: 2026-08-25 10:15:00-05:00
   permalink: null
   room: Sauganash & Wolf Point Ballrooms
-  start_datetime: 2026-08-25 10:20:00-05:00
+  start_datetime: 2026-08-25 09:50:00-05:00
   title: Break
   track: t0
 - end_datetime: 2026-08-25 13:00:00-05:00
@@ -142,10 +142,10 @@
   start_datetime: 2026-08-26 08:00:00-05:00
   title: Speaker Green Room
   track: t0
-- end_datetime: 2026-08-26 10:45:00-05:00
+- end_datetime: 2026-08-26 10:15:00-05:00
   permalink: null
   room: Sauganash & Wolf Point Ballrooms
-  start_datetime: 2026-08-26 10:20:00-05:00
+  start_datetime: 2026-08-26 09:50:00-05:00
   title: Break
   track: t0
 - end_datetime: 2026-08-26 13:00:00-05:00

--- a/src/_content/schedule/talks/2026-08-25-09-00-t0-opening-remarks-tuesday.md
+++ b/src/_content/schedule/talks/2026-08-25-09-00-t0-opening-remarks-tuesday.md
@@ -1,7 +1,7 @@
 ---
 category: talks
 difficulty: All
-end_datetime: 2026-08-25 09:15:00-05:00
+end_datetime: 2026-08-25 09:05:00-05:00
 permalink: /talks/opening-remarks-tuesday/
 presenter_slugs:
 - peter-grandstaff

--- a/src/_content/schedule/talks/2026-08-25-09-05-to-keynote-emails-from-my-grandad.md
+++ b/src/_content/schedule/talks/2026-08-25-09-05-to-keynote-emails-from-my-grandad.md
@@ -1,12 +1,12 @@
 ---
 category: talks
 difficulty: All
-end_datetime: 2026-08-25 10:00:00-05:00
+end_datetime: 2026-08-25 09:50:00-05:00
 permalink: /talks/keynote-tuesday-emails-from-my-grandad/
 presenter_slugs:
   - sarah-boyce
 room: Sauganash Ballroom
-start_datetime: 2026-08-25 09:15:00-05:00
+start_datetime: 2026-08-25 09:05:00-05:00
 title: "Keynote: Emails from my Grandad"
 track: t0
 ---

--- a/src/_content/schedule/talks/2026-08-26-09-00-t0-opening-remarks-wednesday.md
+++ b/src/_content/schedule/talks/2026-08-26-09-00-t0-opening-remarks-wednesday.md
@@ -1,7 +1,7 @@
 ---
 category: talks
 difficulty: All
-end_datetime: 2026-08-26 09:15:00-05:00
+end_datetime: 2026-08-26 09:05:00-05:00
 permalink: /talks/opening-remarks-wednesday/
 presenter_slugs:
 - drew-winstel

--- a/src/_content/schedule/talks/2026-08-26-09-05-t0-keynote-to-be-announced-wednesday.md
+++ b/src/_content/schedule/talks/2026-08-26-09-05-t0-keynote-to-be-announced-wednesday.md
@@ -1,11 +1,11 @@
 ---
 category: talks
 difficulty: All
-end_datetime: 2026-08-26 10:00:00-05:00
+end_datetime: 2026-08-26 09:50:00-05:00
 permalink: /talks/keynote-wednesday/
 presenter_slugs: null
 room: Sauganash Ballroom
-start_datetime: 2026-08-26 09:15:00-05:00
+start_datetime: 2026-08-26 09:05:00-05:00
 title: Keynote (to be announced) (Wednesday)
 track: t0
 ---

--- a/tools/constants.py
+++ b/tools/constants.py
@@ -61,14 +61,14 @@ DAY_1_KEYNOTE_END = DAY_1_KEYNOTE_START + datetime.timedelta(minutes=45)
 DAY_2_OPENING_REMARKS_START = datetime.datetime.combine(
     TALK_DAY_2, datetime.time(9), tzinfo=CONFERENCE_TZ
 )
-DAY_2_OPENING_REMARKS_END = DAY_2_OPENING_REMARKS_START + datetime.timedelta(minutes=15)
+DAY_2_OPENING_REMARKS_END = DAY_2_OPENING_REMARKS_START + datetime.timedelta(minutes=5)
 DAY_2_KEYNOTE_START = DAY_2_OPENING_REMARKS_END
 DAY_2_KEYNOTE_END = DAY_2_KEYNOTE_START + datetime.timedelta(minutes=45)
 
 DAY_3_OPENING_REMARKS_START = datetime.datetime.combine(
     TALK_DAY_3, datetime.time(9), tzinfo=CONFERENCE_TZ
 )
-DAY_3_OPENING_REMARKS_END = DAY_3_OPENING_REMARKS_START + datetime.timedelta(minutes=15)
+DAY_3_OPENING_REMARKS_END = DAY_3_OPENING_REMARKS_START + datetime.timedelta(minutes=5)
 DAY_3_KEYNOTE_START = DAY_3_OPENING_REMARKS_END
 DAY_3_KEYNOTE_END = DAY_3_KEYNOTE_START + datetime.timedelta(minutes=45)
 

--- a/tools/models.py
+++ b/tools/models.py
@@ -471,12 +471,12 @@ MANUAL_SCHEDULE_ENTRIES = [
     ManualScheduleEntry(
         start_datetime=pydatetime.datetime.combine(
             constants.TALK_DAY_2,
-            pydatetime.time(10, 20),
+            pydatetime.time(9, 50),
             tzinfo=constants.CONFERENCE_TZ,
         ),
         end_datetime=pydatetime.datetime.combine(
             constants.TALK_DAY_2,
-            pydatetime.time(10, 45),
+            pydatetime.time(10, 15),
             tzinfo=constants.CONFERENCE_TZ,
         ),
         group="break",
@@ -629,12 +629,12 @@ MANUAL_SCHEDULE_ENTRIES = [
     ManualScheduleEntry(
         start_datetime=pydatetime.datetime.combine(
             constants.TALK_DAY_3,
-            pydatetime.time(10, 20),
+            pydatetime.time(9,50),
             tzinfo=constants.CONFERENCE_TZ,
         ),
         end_datetime=pydatetime.datetime.combine(
             constants.TALK_DAY_3,
-            pydatetime.time(10, 45),
+            pydatetime.time(10, 15),
             tzinfo=constants.CONFERENCE_TZ,
         ),
         group="break",


### PR DESCRIPTION
This fixes the problem with the morning breaks on Tuesday/Wednesday overlapping the talks and also reflects the reality that the opening remarks on both days are typically much shorter.